### PR TITLE
feat: アカウント情報の取得・更新メソッドをSDKに追加

### DIFF
--- a/src/apiClient/api.ts
+++ b/src/apiClient/api.ts
@@ -188,6 +188,12 @@ export interface InlineResponse2002Data {
      * @memberof InlineResponse2002Data
      */
     imgId: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InlineResponse2002Data
+     */
+    signedUrl: string;
 }
 /**
  * 


### PR DESCRIPTION
## チケットへのリンク

- https://app.clickup.com/t/91vn25

ユーザー（ウォレット）がプロフィール設定できるについては、詳しくは以下を参考にしてください。
https://www.notion.so/kyuzan/7df03d7109ce40f48d57df7097be604e

## やったこと

- SDKにアカウント情報の取得・更新に対応したメソッドを追加した
- 一部、写真アップロード部分のAPI定義の修正が必要がったため修正した（APIクライアントはOpenAPIのジェネレーターで自動生成しています）

## やらないこと

- Broad Peakへのつなぎ込み（別PRでやります）

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- UI的な変化なし

## その他

- 