### PR TITLE
イページのスケルトンローディングをFigmaに合わせる

### DIFF
--- a/example/src/components/molecules/CardMyPage/TokenRight.tsx
+++ b/example/src/components/molecules/CardMyPage/TokenRight.tsx
@@ -44,7 +44,7 @@ export const TokenRight: React.VFC<Props> = ({
         <Description>
           フィジカルアイテムの配送先の住所を入力してください
         </Description>
-        <PrimaryLoadingButton
+        <InputAddressButton
           isLoading={false}
           onClick={onWriteShipAddress}
           label={'配送先の住所を入力する'}
@@ -98,6 +98,10 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
+`
+
+const InputAddressButton = styled(PrimaryLoadingButton)`
+  line-height: 19px;
 `
 
 const ReverseButton = styled(PrimaryLoadingButton)`

--- a/example/src/components/molecules/CardMyPage/index.tsx
+++ b/example/src/components/molecules/CardMyPage/index.tsx
@@ -39,10 +39,19 @@ export const CardMyPage: React.VFC<Props> = ({
           <MediaContent media={item?.previews[0]} height={240} />
         </MediaContainer>
         <Center>
-          <Skeleton width={240} height={160} />
+          <Skeleton width={250} height={20} style={{ margin: '0 0 32px 0' }} />
+          <Skeleton width={102} height={24} style={{ marginRight: '8px' }} />
+          <Skeleton width={114} height={24} />
         </Center>
-        <Right>
-          <Skeleton width={200} height={160} />
+        <VerticalLine />
+        <Right style={{ alignItems: 'flex-start' }}>
+          <Skeleton width={120} height={20} style={{ marginBottom: 16 }} />
+          <Skeleton width={222} height={12} count={3} />
+          <Skeleton
+            width={222}
+            height={44}
+            style={{ borderRadius: '22px', margin: '16px 0' }}
+          />
         </Right>
       </Container>
     )
@@ -214,9 +223,8 @@ const isToken = (target: any): target is Token => {
 
 const Container = styled.article`
   overflow: hidden;
-  width: 100%;
+  max-width: 840px;
   display: flex;
-  justify-content: space-between;
   background: ${color.white};
   box-shadow: 0px 9px 16px rgba(0, 0, 0, 0.04),
     0px 2.01027px 3.57381px rgba(0, 0, 0, 0.0238443),
@@ -232,9 +240,12 @@ const MediaContainer = styled.div`
 
 const Center = styled.div`
   width: 316px;
-  padding: 32px 0;
+  padding: 32px;
 `
-
+const VerticalLine = styled.div`
+  border-left: thin solid ${color.content.gray};
+  margin: 32px 0;
+`
 const CenterTitleContainer = styled.div``
 
 const CenterTitle = styled.h1`
@@ -261,7 +272,7 @@ const Right = styled.div`
   align-items: center;
   justify-content: center;
   width: 254px;
-  padding: 32px 32px 32px 0;
+  padding: 32px;
 `
 
 const RightTitleContainer = styled.div`


### PR DESCRIPTION
## チケットへのリンク

- https://app.clickup.com/t/8m1ykv

## やったこと

- ローディングのデザインをFigmaと合わせました

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- ![loadingimage](https://user-images.githubusercontent.com/8515141/122238528-294da680-cefb-11eb-8d5d-2cc978dc4d1e.png)


## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
