### PR TITLE
ウォレットアドレスコピーボタン

### DIFF
--- a/example/src/components/atoms/Clipboard/index.stories.tsx
+++ b/example/src/components/atoms/Clipboard/index.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { ClipBoard } from '.'
+
+export const Basic: React.VFC = () => (
+  <ClipBoard text={'0x99A00d5430Eb9ee2B8eB9385b72aB17Fb1b15f2B'} />
+)
+
+export default {
+  title: 'atoms/Clipboard',
+}

--- a/example/src/components/atoms/Clipboard/index.tsx
+++ b/example/src/components/atoms/Clipboard/index.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled'
+import React, { useCallback, useState } from 'react'
+import copy from 'clipboard-copy'
+import Image from 'next/image'
+import { color, font } from '../../../style'
+
+type Props = {
+  text?: string
+  className?: string
+}
+
+export const ClipBoard: React.VFC<Props> = ({ text, className }) => {
+  const [showCheck, setShowCheck] = useState(false)
+  const clickCopy = useCallback(() => {
+    copy(text ?? '')
+    setShowCheck(true)
+    setTimeout(() => {
+      setShowCheck(false)
+    }, 2000)
+  }, [text])
+  return (
+    <Container className={className}>
+      {!showCheck && (
+        <CopyIcon onClick={clickCopy}>
+          <Image
+            src={'/images/icons/clipboard.svg'}
+            layout={'fixed'}
+            width={16}
+            height={16}
+          />
+        </CopyIcon>
+      )}
+      {showCheck && (
+        <CheckIcon>
+          <ToolTip>クリックボードにコピーしました</ToolTip>
+          <Image
+            src={'/images/icons/check.svg'}
+            layout={'fixed'}
+            width={16}
+            height={16}
+          />
+        </CheckIcon>
+      )}
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`
+
+const CopyIcon = styled.div`
+  margin-left: 8px;
+  cursor: pointer;
+`
+
+const CheckIcon = styled.div`
+  margin-left: 8px;
+  cursor: pointer;
+  position: relative;
+`
+
+const ToolTip = styled.div`
+  background-color: ${color.background.dark};
+  border-radius: 16px;
+  padding: 8px 16px;
+  color: ${color.white};
+  ${font.lg.caption}
+  position: absolute;
+  width: 222px;
+  height: 31px;
+  top: -33px;
+  right: -125px;
+`

--- a/example/src/components/organisms/Header/presentation.tsx
+++ b/example/src/components/organisms/Header/presentation.tsx
@@ -7,6 +7,7 @@ import { font } from '../../../style'
 import { Anchor } from '../../atoms/Anchor'
 import { DefaultAvatarIcon } from '../../atoms/DefaultAvatarIcon'
 import { PrimaryLoadingButton } from '../../atoms/LoadingBotton'
+import { ClipBoard } from '../../atoms/Clipboard'
 
 type Props = {
   loading: boolean
@@ -62,6 +63,7 @@ export const Presentation: React.VFC<Props> = ({
                       <WalletBalance>{walletBalance}</WalletBalance>
                       <WalletAddress>
                         {walletAddress?.slice(0, 8)}
+                        <ClipBoard text={walletAddress} />
                       </WalletAddress>
                     </WalletDetail>
                   </WalletInfoContainer>
@@ -146,6 +148,10 @@ const WalletBalance = styled.div`
 
 const WalletAddress = styled.div`
   ${font.lg.caption}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
 `
 
 const LoadingContainer = styled.div`


### PR DESCRIPTION
## チケットへのリンク

- https://app.clickup.com/t/8m220h
- 
## やったこと

- ウォレットアドレスのコピーボタンを作りました

## やらないこと

- なし

## できるようになること（ユーザ目線）

- コピーできる

## できなくなること（ユーザ目線）

- なし

## 動作確認
![Screenshot 2021-07-30 225541](https://user-images.githubusercontent.com/8515141/127663648-7494fbc3-293d-41b7-92c0-8c330011626b.png)

## その他

- ツールチップのコンポーネントを使って作れるようにしたかったんですが、表示位置などの関係により、今回はつかわない方向でつくりました。
