### PR TITLE
オークション終了まで5minを切ったらデータの更新がXsec（いったん30sec）程度ごとに行われるようにす

### DIFF
--- a/example/src/components/molecules/Detail/active.tsx
+++ b/example/src/components/molecules/Detail/active.tsx
@@ -9,7 +9,7 @@ type LiveProps = {
   price: number
   unit: string
   onComplete: () => void
-  onTick: (calcTimeData: CountdownTimeDelta) => void
+  onTick?: (calcTimeData: CountdownTimeDelta) => void
 }
 
 type FormattedProps = {

--- a/example/src/components/molecules/Detail/active.tsx
+++ b/example/src/components/molecules/Detail/active.tsx
@@ -8,6 +8,7 @@ type LiveProps = {
   price: number
   unit: string
   onComplete: () => void
+  onTick: (calcTimeData: object) => void
 }
 
 type FormattedProps = {
@@ -55,6 +56,7 @@ export const LiveStatus: React.FC<LiveProps> = ({
   unit,
   endAt,
   onComplete,
+  onTick,
 }) => {
   return (
     <StatusContainer>
@@ -71,6 +73,7 @@ export const LiveStatus: React.FC<LiveProps> = ({
           date={endAt ?? 0 - Date.now()}
           renderer={renderer}
           onComplete={onComplete}
+          onTick={onTick}
         />
       </TimeContent>
     </StatusContainer>

--- a/example/src/components/molecules/Detail/active.tsx
+++ b/example/src/components/molecules/Detail/active.tsx
@@ -8,7 +8,7 @@ type LiveProps = {
   price: number
   unit: string
   onComplete: () => void
-  onTick: (calcTimeData: object) => void
+  onTick: (calcTimeData: any) => void
 }
 
 type FormattedProps = {

--- a/example/src/components/molecules/Detail/active.tsx
+++ b/example/src/components/molecules/Detail/active.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import Countdown from 'react-countdown'
 import styled from '@emotion/styled'
 import { color, font, media } from '../../../style'
+import { CountdownTimeDelta } from 'react-countdown'
 
 type LiveProps = {
   endAt: Date
   price: number
   unit: string
   onComplete: () => void
-  onTick: (calcTimeData: any) => void
+  onTick: (countdownTimeDelta: CountdownTimeDelta) => void
 }
 
 type FormattedProps = {

--- a/example/src/components/molecules/Detail/active.tsx
+++ b/example/src/components/molecules/Detail/active.tsx
@@ -9,7 +9,7 @@ type LiveProps = {
   price: number
   unit: string
   onComplete: () => void
-  onTick: (countdownTimeDelta: CountdownTimeDelta) => void
+  onTick: (calcTimeData: CountdownTimeDelta) => void
 }
 
 type FormattedProps = {

--- a/example/src/components/molecules/Detail/index.stories.tsx
+++ b/example/src/components/molecules/Detail/index.stories.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { StatusDetail } from '.'
-import { addDays, subDays } from 'date-fns'
+import { addDays, addMinutes, subDays } from 'date-fns'
+import { action } from '@storybook/addon-actions'
 
 export const Live: React.VFC = () => (
   <StatusDetail
     price={0.2}
     unit={'ETH'}
-    endAt={addDays(new Date(), 10)}
+    endAt={addMinutes(new Date(), 5)}
     tradeType={'autoExtensionAuction'}
+    onTick={action('onTick')}
   />
 )
 
@@ -17,6 +19,7 @@ export const LivePolygon: React.VFC = () => (
     unit={'MATIC'}
     endAt={addDays(new Date(), 10)}
     tradeType={'autoExtensionAuction'}
+    onTick={action('onTick')}
   />
 )
 
@@ -26,6 +29,7 @@ export const End: React.VFC = () => (
     unit={'ETH'}
     endAt={subDays(new Date(), 10)}
     tradeType={'autoExtensionAuction'}
+    onTick={action('onTick')}
   />
 )
 

--- a/example/src/components/molecules/Detail/index.tsx
+++ b/example/src/components/molecules/Detail/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   endAt: Date
   price: number
   unit: string
+  onTick: (time: object) => void
 }
 
 export const StatusDetail: React.FC<Props> = ({
@@ -18,6 +19,7 @@ export const StatusDetail: React.FC<Props> = ({
   price,
   unit,
   tradeType,
+  onTick,
 }) => {
   const isAuction = tradeType === 'autoExtensionAuction'
 
@@ -36,6 +38,7 @@ export const StatusDetail: React.FC<Props> = ({
             price={price}
             unit={unit}
             onComplete={updateTime}
+            onTick={onTick}
           />
         )}
         {isEnded && <EndedStatus endAt={endAt} unit={unit} price={price} />}

--- a/example/src/components/molecules/Detail/index.tsx
+++ b/example/src/components/molecules/Detail/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   endAt: Date
   price: number
   unit: string
-  onTick: (calcTimeData: CountdownTimeDelta) => void
+  onTick?: (calcTimeData: CountdownTimeDelta) => void
 }
 
 export const StatusDetail: React.FC<Props> = ({

--- a/example/src/components/molecules/Detail/index.tsx
+++ b/example/src/components/molecules/Detail/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   endAt: Date
   price: number
   unit: string
-  onTick: (countdownTimeDelta: CountdownTimeDelta) => void
+  onTick: (calcTimeData: CountdownTimeDelta) => void
 }
 
 export const StatusDetail: React.FC<Props> = ({

--- a/example/src/components/molecules/Detail/index.tsx
+++ b/example/src/components/molecules/Detail/index.tsx
@@ -5,13 +5,14 @@ import { LiveStatus } from './active'
 import { EndedStatus } from './ended'
 import styled from '@emotion/styled'
 import { color, font } from '../../../style'
+import { CountdownTimeDelta } from 'react-countdown'
 
 type Props = {
   tradeType: ItemTradeType
   endAt: Date
   price: number
   unit: string
-  onTick: (time: any) => void
+  onTick: (countdownTimeDelta: CountdownTimeDelta) => void
 }
 
 export const StatusDetail: React.FC<Props> = ({

--- a/example/src/components/molecules/Detail/index.tsx
+++ b/example/src/components/molecules/Detail/index.tsx
@@ -11,7 +11,7 @@ type Props = {
   endAt: Date
   price: number
   unit: string
-  onTick: (time: object) => void
+  onTick: (time: any) => void
 }
 
 export const StatusDetail: React.FC<Props> = ({

--- a/example/src/components/organisms/ItemDetail/container.tsx
+++ b/example/src/components/organisms/ItemDetail/container.tsx
@@ -61,8 +61,23 @@ export const Container: React.VFC = () => {
   const [bidPrice, setBidPrice] = useState(`0.0`)
   const [isError, setError] = useState(false)
   const [errorText, setErrorText] = useState('')
+  const [counter, setCounter] = useState(0)
 
   const isMobile = useMedia()
+
+  const onTick = useCallback(
+    (calcTimeDelta) => {
+      // within 5 minutes
+      if (calcTimeDelta.total < 300000) {
+        console.log('call')
+        if (counter === 0) {
+          updateInfo()
+        }
+        setCounter((prev) => (prev + 1) % 30)
+      }
+    },
+    [counter]
+  )
 
   useEffect(() => {
     if (bidPrice < (item?.minBidPrice ?? bidPrice)) {
@@ -236,6 +251,7 @@ export const Container: React.VFC = () => {
       isValidationError={isError}
       errorText={errorText}
       taHash={bidHash}
+      onTick={onTick}
     />
   )
 }

--- a/example/src/components/organisms/ItemDetail/container.tsx
+++ b/example/src/components/organisms/ItemDetail/container.tsx
@@ -16,6 +16,10 @@ import { getNetworkIdLabel } from '../../../util/getNetworkIdLabel'
 import { Presentation } from './presentation'
 import { useMedia } from '../../../util/useMedia'
 import router from 'next/router'
+import { CountdownTimeDelta } from 'react-countdown'
+
+const WITHIN_TIME = 300000 //5 minutes
+const EACH_TIME = 30000 // 30 seconds
 
 export const Container: React.VFC = () => {
   const dispatch = useAppDispatch()
@@ -61,23 +65,17 @@ export const Container: React.VFC = () => {
   const [bidPrice, setBidPrice] = useState(`0.0`)
   const [isError, setError] = useState(false)
   const [errorText, setErrorText] = useState('')
-  const [counter, setCounter] = useState(0)
 
   const isMobile = useMedia()
 
-  const onTick = useCallback(
-    (calcTimeDelta) => {
-      // within 5 minutes
-      if (calcTimeDelta.total < 300000) {
-        console.log('call')
-        if (counter === 0) {
-          updateInfo()
-        }
-        setCounter((prev) => (prev + 1) % 30)
+  const onTick = useCallback((calcTimeDelta: CountdownTimeDelta) => {
+    // within 5 minutes
+    if (calcTimeDelta.total < WITHIN_TIME) {
+      if (calcTimeDelta.total % EACH_TIME === 0) {
+        updateInfo()
       }
-    },
-    [counter]
-  )
+    }
+  }, [])
 
   useEffect(() => {
     if (bidPrice < (item?.minBidPrice ?? bidPrice)) {

--- a/example/src/components/organisms/ItemDetail/index.stories.tsx
+++ b/example/src/components/organisms/ItemDetail/index.stories.tsx
@@ -42,6 +42,7 @@ export const Basic: React.VFC = () => {
       isValidationError={false}
       errorText={''}
       taHash={''}
+      onTick={action('onTick')}
     />
   )
 }
@@ -84,6 +85,7 @@ export const AuctionIsOutOfDate: React.VFC = () => {
       isValidationError={false}
       errorText={''}
       taHash={''}
+      onTick={action('onTick')}
     />
   )
 }
@@ -126,6 +128,7 @@ export const Loading: React.VFC = () => {
       isValidationError={false}
       errorText={''}
       taHash={''}
+      onTick={action('onTick')}
     />
   )
 }

--- a/example/src/components/organisms/ItemDetail/presentation.tsx
+++ b/example/src/components/organisms/ItemDetail/presentation.tsx
@@ -48,7 +48,7 @@ type Props = {
   isValidationError: boolean
   errorText: string
   taHash?: string
-  onTick: (time: object) => void
+  onTick: (time: any) => void
 }
 
 export const Presentation: React.VFC<Props> = ({

--- a/example/src/components/organisms/ItemDetail/presentation.tsx
+++ b/example/src/components/organisms/ItemDetail/presentation.tsx
@@ -48,6 +48,7 @@ type Props = {
   isValidationError: boolean
   errorText: string
   taHash?: string
+  onTick: (time: object) => void
 }
 
 export const Presentation: React.VFC<Props> = ({
@@ -79,6 +80,7 @@ export const Presentation: React.VFC<Props> = ({
   isValidationError,
   errorText,
   taHash: bidHash,
+  onTick,
 }) => {
   if (loading) {
     return <LoadingItemDetailComponent />
@@ -115,6 +117,7 @@ export const Presentation: React.VFC<Props> = ({
             price={getItemPrice(item)}
             endAt={item?.endAt ?? new Date()}
             tradeType={item?.tradeType ?? 'fixedPrice'}
+            onTick={onTick}
           />
           {item?.type === 'nftWithPhysicalProduct' && (
             <QuestionButton onClick={handleOpenPhysicalModal}>

--- a/example/src/components/organisms/ItemDetail/presentation.tsx
+++ b/example/src/components/organisms/ItemDetail/presentation.tsx
@@ -18,6 +18,7 @@ import { BidSuccessModal } from '../../molecules/BidSuccessModal'
 import { BoughtFixedPriceSuccessModal } from '../../molecules/BoughtFixedPriceSuccessModal'
 import { PrimaryButton } from '../../atoms/PrimaryButton'
 import { isOnSale } from '../../../util/isOnSale'
+import { CountdownTimeDelta } from 'react-countdown'
 
 type Props = {
   loading: boolean
@@ -48,7 +49,7 @@ type Props = {
   isValidationError: boolean
   errorText: string
   taHash?: string
-  onTick: (time: any) => void
+  onTick: (calcTimeDelta: CountdownTimeDelta) => void
 }
 
 export const Presentation: React.VFC<Props> = ({


### PR DESCRIPTION
## チケットへのリンク

- https://app.clickup.com/t/9j0366

## やったこと

- 5min切ったら詳細ページで30秒おきにデータを取得しなおすようにしました

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？
- UI が関わるものは、スクショや動画を添付

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
