### PR TITLE
デモサイト修正: 固定価格アイテム表示修正 & 入札時表示修正

### DIFF
--- a/example/src/components/organisms/ItemDetail/presentation.tsx
+++ b/example/src/components/organisms/ItemDetail/presentation.tsx
@@ -95,6 +95,7 @@ export const Presentation: React.VFC<Props> = ({
     (typeof item?.endAt === 'string' ? new Date(item?.endAt) : item?.endAt) ??
     new Date()
   const saleOnGoing = isOnSale(startDate, endDate)
+  const hasBought = typeof item?.buyerAddress === 'string'
 
   return (
     <>
@@ -149,24 +150,19 @@ export const Presentation: React.VFC<Props> = ({
           )}
         </TradeInfoContainer>
 
-        {saleOnGoing && (
-          <BidButton
-            label={
-              item?.tradeType === 'autoExtensionAuction'
-                ? '入札する'
-                : '購入する'
-            }
-            onClick={handleOpenBidModal}
-          />
-        )}
+        {item?.tradeType === 'autoExtensionAuction' &&
+          (saleOnGoing ? (
+            <BidButton label={'入札する'} onClick={handleOpenBidModal} />
+          ) : (
+            <BidButton label={'売り切れ'} disabled={true} />
+          ))}
 
-        {!saleOnGoing && (
-          <BidButton
-            label={'売り切れ'}
-            // onClick={action('onClick')}
-            disabled={true}
-          />
-        )}
+        {item?.tradeType !== 'autoExtensionAuction' &&
+          (!hasBought ? (
+            <BidButton label={'購入する'} onClick={handleOpenBidModal} />
+          ) : (
+            <BidButton label={'売り切れ'} disabled={true} />
+          ))}
 
         <Description>{item?.description}</Description>
         <SecondaryButtonUL>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@kyuzan/mint-sdk-js",
-      "version": "5.12.0",
+      "version": "5.13.0",
       "dependencies": {
         "@emotion/babel-plugin": "^11.3.0",
         "agentkeepalive": "^4.1.4",


### PR DESCRIPTION
## チケットへのリンク
#76  

## やったこと

- このプルリクで何をしたのか？
デモサイトで、固定価格アイテムが売り切れ時でも購入ができてしまうUIになっていたのを修正

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
なし

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
売り切れアイテムの購入ボタンが適切に表示される用になる

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
なし

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？
- UI が関わるものは、スクショや動画を添付

売り切れ時はボタンをdisabledに変更
![スクリーンショット 2021-11-05 18 20 05](https://user-images.githubusercontent.com/30888315/140487724-2c7c6344-fa5e-4d72-836e-3ab6301b49e2.png)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
