### PR TITLE
Add function to open fortmatic account settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export class MintSDK {
     return await this.walletStrategy.getWalletInfo()
   }
 
-    /**
+  /**
    * ウォレット設定を開く（Fortmaticのみ）
    *
    * **Required**

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,25 @@ export class MintSDK {
     return await this.walletStrategy.getWalletInfo()
   }
 
+    /**
+   * ウォレット設定を開く（Fortmaticのみ）
+   *
+   * **Required**
+   * - ウォレットに接続していること
+   *
+   * @returns
+   *
+   * ```typescript
+   * import { MintSDK } from '@kyuzan/mint-sdk-js'
+   * const sdk = await MintSDK.initialize(...)
+   * await sdk.connectWallet()  // required
+   * await sdk.openSettings()
+   * ```
+   */
+  public openSettings: () => Promise<void> = async () => {
+    return await this.walletStrategy.openSettings()
+  }
+
   /**
    * Transactionが成功するとResolveするPromiseを返します
    *

--- a/src/strategies/FortmaticStrategy.ts
+++ b/src/strategies/FortmaticStrategy.ts
@@ -45,6 +45,10 @@ export class FortmaticStrategy implements WalletStrategy {
     }
   }
 
+  async openSettings() {
+    return this.fortmatic.user.settings()
+  }
+
   getProvider() {
     const provider = this.fortmatic.getProvider()
     return new ethers.providers.Web3Provider(provider as any)

--- a/src/strategies/MetamaskStrategy.ts
+++ b/src/strategies/MetamaskStrategy.ts
@@ -54,6 +54,10 @@ export class MetamaskStrategy implements WalletStrategy {
     }
   }
 
+  async openSettings() {
+    return
+  }
+
   getProvider() {
     return this.metamaskProvider
   }

--- a/src/strategies/MetamaskStrategy.ts
+++ b/src/strategies/MetamaskStrategy.ts
@@ -55,7 +55,8 @@ export class MetamaskStrategy implements WalletStrategy {
   }
 
   async openSettings() {
-    return
+    throw new Error('this method is not available in metamask strategy')
+    return null as never
   }
 
   getProvider() {

--- a/src/strategies/NodeStrategy.ts
+++ b/src/strategies/NodeStrategy.ts
@@ -15,6 +15,11 @@ export class NodeStrategy implements WalletStrategy {
     return null as never
   }
 
+  async openSettings() {
+    throw new Error('this method should not call in node context')
+    return null as never
+  }
+
   getProvider() {
     throw new Error('this method should not call in node context')
     return null as never

--- a/src/strategies/interface.ts
+++ b/src/strategies/interface.ts
@@ -6,6 +6,7 @@ export interface WalletStrategy {
   connectWallet(): Promise<void>
   getConnectedNetworkId(): Promise<number>
   getWalletInfo(): Promise<WalletInfo>
+  openSettings(): Promise<void>
   getProvider(): ethers.providers.Web3Provider
   disconnectWallet(): Promise<void>
   onAccountsChange(callback: (accounts: string[]) => any): void


### PR DESCRIPTION
## チケットへのリンク

None

## やったこと

Add a function open fortmatic's user settings

## やらないこと

None

## できるようになること（ユーザ目線）

Calling the following function will open Fortmatic's user settings where 2FA, email, password can be changed and the private key can be exported.
```js
sdk.openSettings()
```

## できなくなること（ユーザ目線）

None

## 動作確認

Tested the function manually in a Rinkeby environment
![Untitled](https://user-images.githubusercontent.com/8691156/146729137-8b94b93d-72fe-4561-a8bb-58ccf8da91b1.png)

## その他

As far as I know, only Fortmatic's settings window can be opened, so any settings button in a website using the library should account for the fact that the function will not do anything when MetaMask is used.

