### PR TITLE
add contractAddress on getTokenERC721sByWalletAddress api

### DIFF
--- a/src/apiClient/api.ts
+++ b/src/apiClient/api.ts
@@ -2922,10 +2922,11 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {string} walletAddress 
          * @param {string} page 
          * @param {string} perPage 
+         * @param {string} [contractAddress] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getTokenERC721sByWalletAddress: async (mintAccessToken: string, walletAddress: string, page: string, perPage: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getTokenERC721sByWalletAddress: async (mintAccessToken: string, walletAddress: string, page: string, perPage: string, contractAddress?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'mintAccessToken' is not null or undefined
             assertParamExists('getTokenERC721sByWalletAddress', 'mintAccessToken', mintAccessToken)
             // verify required parameter 'walletAddress' is not null or undefined
@@ -2956,6 +2957,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             if (perPage !== undefined) {
                 localVarQueryParameter['perPage'] = perPage;
+            }
+
+            if (contractAddress !== undefined) {
+                localVarQueryParameter['contractAddress'] = contractAddress;
             }
 
             if (mintAccessToken !== undefined && mintAccessToken !== null) {
@@ -3440,11 +3445,12 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {string} walletAddress 
          * @param {string} page 
          * @param {string} perPage 
+         * @param {string} [contractAddress] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetTokenERC721sByWalletAddress200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, options);
+        async getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, contractAddress?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetTokenERC721sByWalletAddress200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, contractAddress, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3746,11 +3752,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {string} walletAddress 
          * @param {string} page 
          * @param {string} perPage 
+         * @param {string} [contractAddress] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, options?: any): AxiosPromise<GetTokenERC721sByWalletAddress200Response> {
-            return localVarFp.getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, options).then((request) => request(axios, basePath));
+        getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, contractAddress?: string, options?: any): AxiosPromise<GetTokenERC721sByWalletAddress200Response> {
+            return localVarFp.getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, contractAddress, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -4085,12 +4092,13 @@ export class DefaultApi extends BaseAPI {
      * @param {string} walletAddress 
      * @param {string} page 
      * @param {string} perPage 
+     * @param {string} [contractAddress] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, options).then((request) => request(this.axios, this.basePath));
+    public getTokenERC721sByWalletAddress(mintAccessToken: string, walletAddress: string, page: string, perPage: string, contractAddress?: string, options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getTokenERC721sByWalletAddress(mintAccessToken, walletAddress, page, perPage, contractAddress, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -619,12 +619,14 @@ export class MintSDK {
     walletAddress: string
     page: number
     perPage: number
+    contractAddress?: string
   }) => {
     const { data } = await this.apiClientV2.getTokenERC721sByWalletAddress(
       this.accessToken,
       arg.walletAddress,
       arg.page.toString(),
-      arg.perPage.toString()
+      arg.perPage.toString(),
+      arg.contractAddress
     )
     return data.data
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
add contractAddress on getTokenERC721sByWalletAddress api
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
no contracAddress params on add getTokenERC721sByWalletAddress function
Related Ticket: N/A


## What is the new behavior?
has contracAddress params on add getTokenERC721sByWalletAddress function

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
